### PR TITLE
Update Bannerlord target versions for stable and beta builds

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -13,8 +13,13 @@
     <BUTRAnalyzerVersion>1.0.1.12</BUTRAnalyzerVersion>
     <BUTRSharedVersion>3.0.0.142</BUTRSharedVersion>
     <BUTRModuleManagerVersion>6.0.247</BUTRModuleManagerVersion>
-    <!--Current Bannerlord Version-->
-    <GameVersion>1.3.4</GameVersion>
+    <!--Current Bannerlord Versions-->
+    <StableGameVersion Condition="'$(StableGameVersion)' == ''">1.3.15</StableGameVersion>
+    <BetaGameVersion Condition="'$(BetaGameVersion)' == ''">1.4.1</BetaGameVersion>
+    <IsBetaConfiguration>false</IsBetaConfiguration>
+    <IsBetaConfiguration Condition="$(Configuration) == 'Beta_Debug' OR $(Configuration) == 'Beta_Release'">true</IsBetaConfiguration>
+    <GameVersion Condition="'$(GameVersion)' == '' AND '$(IsBetaConfiguration)' == 'true'">$(BetaGameVersion)</GameVersion>
+    <GameVersion Condition="'$(GameVersion)' == '' AND '$(IsBetaConfiguration)' != 'true'">$(StableGameVersion)</GameVersion>
     <GameVersionWithPrefix>v$(GameVersion)</GameVersionWithPrefix>
     <!--Bannerlord's Root Folder. Leave empty if you want it to be tried to be autoresolved.-->
     <GameFolder Condition="$(Configuration) == 'Stable_Debug' OR $(Configuration) == 'Stable_Release'">$(BANNERLORD_STABLE_DIR)</GameFolder>


### PR DESCRIPTION
Update the build version selection so the project no longer hardcodes `GameVersion` to `1.3.4`.

Changes
- add `StableGameVersion` defaulting to `1.3.15`
- add `BetaGameVersion` defaulting to `1.4.1`
- select `GameVersion` from the active build configuration
- keep `GameVersion` overridable from the command line
 Why
Previously, both stable and beta configurations resolved to the same hardcoded game version, which caused:
- outdated reference assemblies to be used during build
- generated module metadata to advertise only `v1.3.4.*`
- beta configurations to miss API compatibility issues for newer game versions
This change keeps the existing build flow intact while making stable and beta outputs target different Bannerlord versions as intended.
